### PR TITLE
Small fixes

### DIFF
--- a/src/core/components/scene/camera.js
+++ b/src/core/components/scene/camera.js
@@ -1,13 +1,13 @@
 angular.module('components.scene.camera', ['ces', 'three'])
     .config(function ($componentsProvider) {
         'use strict';
+        var renderer = new THREE.WebGLRenderer({antialias: true});
 
         $componentsProvider.addComponentData({
             'camera': {
                 // TODO: this needs to be linked to the actual dom element
-                // But I can't access $rootWorld here, not sure how to solve yet
-                aspectRatio: window.innerWidth / window.innerHeight,
-                // aspectRatio: $rootWorld.renderer.domElement.width / $rootWorld.renderer.domElement.height,
+                // FIXED: var renderer = new THREE.WebGLRenderer({antialias: true});
+                aspectRatio: renderer.domElement.width / renderer.domElement.height,
                 nearClip: 0.1,
                 farClip: 1000,
                 fov: 45,


### PR DESCRIPTION
1: FIXED TODO

Added var renderer = new THREE.WebGLRenderer({antialias: true});

It will now use the dom element.

Though it will give you an error for not defining THREE, it runs perfectly fine
